### PR TITLE
Extra underscore in the usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ composer dump-autoload --optimize
 # Usage
 
 ```php
-$client = new MinhD\DataCite_Client($username, $password);
+$client = new MinhD\DataCiteClient($username, $password);
 $xml = "<some sample XML here>";
 $doi = "10.000/00/123456";
 $url = "http://example.com";


### PR DESCRIPTION
This underscore is not part of the class name.